### PR TITLE
Armor: Switch API compatibility checker to blocking mode

### DIFF
--- a/public_headers/config.yml
+++ b/public_headers/config.yml
@@ -3,7 +3,7 @@ project: https://github.com/AudioReach/audioreach-audio-utils
 branches:
   main:
     modes:
-      non-blocking:
+      blocking:
         headers:
           - audio-route/include/system/*.h
           - audio-route/include/audio_route/*.h


### PR DESCRIPTION
Update config.yml in public_headers to enforce backward compatibility rules for public API headers.