### PR TITLE
Update copyright headers to reflect Qualcomm Technologies, Inc.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,33 +1,28 @@
-Copyright (c) 2024, Qualcomm Innovation Center, Inc. All rights reserved.
+Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 
 Redistribution and use in source and binary forms, with or without
-modification, are permitted (subject to the limitations in the
-disclaimer below) provided that the following conditions are met:
+modification, are permitted provided that the following conditions are
+met:
+* Redistributions of source code must retain the above copyright
+  notice, this list of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the above
+  copyright notice, this list of conditions and the following
+  disclaimer in the documentation and/or other materials provided
+  with the distribution.
+* Neither the name of the copyright holder nor the names of its
+  contributors may be used to endorse or promote products derived
+  from this software without specific prior written permission.
 
-    * Redistributions of source code must retain the above copyright
-      notice, this list of conditions and the following disclaimer.
-
-    * Redistributions in binary form must reproduce the above
-      copyright notice, this list of conditions and the following
-      disclaimer in the documentation and/or other materials provided
-      with the distribution.
-
-    * Neither the name of Qualcomm Innovation Center, Inc. nor the names of its
-      contributors may be used to endorse or promote products derived
-      from this software without specific prior written permission.
-
-NO EXPRESS OR IMPLIED LICENSES TO ANY PARTY'S PATENT RIGHTS ARE
-GRANTED BY THIS LICENSE. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT
-HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+THIS SOFTWARE IS PROVIDED "AS IS" AND ANY EXPRESS OR IMPLIED
 WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
-MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
-IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
-ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
-GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
-IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
-OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT
+ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS
+BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
 IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-SPDX-License-Identifier: BSD-3-Clause-Clear
+SPDX-License-Identifier: BSD-3-Clause

--- a/README.md
+++ b/README.md
@@ -8,4 +8,4 @@ To be available soon.
 
 ## License:
 
-Audioreach-audio-utils source files are licensed under the BSD-3-Clause-Clear. Check out the LICENSE for more details.
+Audioreach-audio-utils source files are licensed under the BSD-3-Clause. Check out the LICENSE for more details.

--- a/audio-log-utils/audio_dynamic_log.xml
+++ b/audio-log-utils/audio_dynamic_log.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 
-<!--- Copyright (c) 2024 Qualcomm Innovation Center, Inc. All rights reserved. -->
-<!--- SPDX-License-Identifier: BSD-3-Clause-Clear                        --> 
+<!--- Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries. -->
+<!--- SPDX-License-Identifier: BSD-3-Clause                        --> 
 
 
 

--- a/audio-log-utils/inc/log_utils.h
+++ b/audio-log-utils/inc/log_utils.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2024 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  *
  */
 

--- a/audio-log-utils/inc/log_xml_parser.h
+++ b/audio-log-utils/inc/log_xml_parser.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2024 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  *
  */
 

--- a/audio-log-utils/src/log_utils.c
+++ b/audio-log-utils/src/log_utils.c
@@ -1,7 +1,7 @@
 /*
  *
- * Copyright (c) 2024 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #define LOG_TAG "audio_log_utils"

--- a/audio-log-utils/src/log_xml_parser.c
+++ b/audio-log-utils/src/log_xml_parser.c
@@ -4,8 +4,8 @@
  * for audio modules.
  *
  *
- * Copyright (c) 2024 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 #define LOG_TAG "log_xml_parser"
 /* #define LOG_NDEBUG 0 */

--- a/audio-plugins/audio-plugin-headers/interface/codec_plugin.h
+++ b/audio-plugins/audio-plugin-headers/interface/codec_plugin.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2024 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 #include <stdint.h>
 #include <stddef.h>

--- a/audio-plugins/audio-plugin-headers/interface/codec_status.h
+++ b/audio-plugins/audio-plugin-headers/interface/codec_status.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2024 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #ifndef _CDC_STATUS_H_

--- a/audio-plugins/dac_plugin/inc/dac_plugin.h
+++ b/audio-plugins/dac_plugin/inc/dac_plugin.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2024 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 #include "codec_plugin.h"
 #include <stdint.h>

--- a/audio-plugins/dac_plugin/src/dac_plugin.c
+++ b/audio-plugins/dac_plugin/src/dac_plugin.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2024 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #include "codec_status.h"

--- a/audio-plugins/mercury_plugin/inc/mercury_plugin.h
+++ b/audio-plugins/mercury_plugin/inc/mercury_plugin.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2024 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 #include "codec_plugin.h"
 #include <stdint.h>

--- a/audio-plugins/mercury_plugin/src/mercury_plugin.c
+++ b/audio-plugins/mercury_plugin/src/mercury_plugin.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2024 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #include "codec_status.h"

--- a/audio-plugins/test/dac_mer_test/dac_mer_testapp.c
+++ b/audio-plugins/test/dac_mer_test/dac_mer_testapp.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2024 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 #include <stdio.h>
 #include <dlfcn.h>

--- a/audio-plugins/test/dac_mer_test/dac_mer_testapp.h
+++ b/audio-plugins/test/dac_mer_test/dac_mer_testapp.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2024 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #ifndef _DAC_MER_TEST_H_

--- a/audio-route/audio_route.c
+++ b/audio-route/audio_route.c
@@ -14,10 +14,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
- *Changes from Qualcomm Innovation Center are provided under the following license:
+ *Changes from Qualcomm Technologies, Inc. are provided under the following license:
  *
- *Copyright (c) 2023-2024 Qualcomm Innovation Center, Inc. All rights reserved.
- *SPDX-License-Identifier: BSD-3-Clause-Clear
+ *Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ *SPDX-License-Identifier: BSD-3-Clause
  */
 
 #define LOG_TAG "audio_route"

--- a/audio-route/include/system/audio.h
+++ b/audio-route/include/system/audio.h
@@ -13,10 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
- * Changes from Qualcomm Innovation Center are provided under the following license:
+ * Changes from Qualcomm Technologies, Inc. are provided under the following license:
  *
- * Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 

--- a/audio_memlogger/armemlog/inc/graph_queue.h
+++ b/audio_memlogger/armemlog/inc/graph_queue.h
@@ -6,8 +6,8 @@
 *      Defines memory structures & logging states
 *      for the graph memory queue.
 *
-*  Copyright (c) Qualcomm Innovation Center, Inc. All rights reserved.
-*  SPDX-License-Identifier: BSD-3-Clause-Clear
+*  Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+*  SPDX-License-Identifier: BSD-3-Clause
 */
 
 #include <stdint.h>

--- a/audio_memlogger/armemlog/inc/kpi_queue.h
+++ b/audio_memlogger/armemlog/inc/kpi_queue.h
@@ -5,8 +5,8 @@
 * \brief
 *      Defines memory structure for the KPI memory queue.
 *
-*  Copyright (c) Qualcomm Innovation Center, Inc. All rights reserved.
-*  SPDX-License-Identifier: BSD-3-Clause-Clear
+*  Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+*  SPDX-License-Identifier: BSD-3-Clause
 */
 
 #define MEM_LOGGER_FUNC_NAME_MAX 61 // 61 to efficiently pack bytes into struct

--- a/audio_memlogger/armemlog/inc/mem_logger.h
+++ b/audio_memlogger/armemlog/inc/mem_logger.h
@@ -6,8 +6,8 @@
 *      Defines platform agnostic APIs for logging items to memory
        and dumping them to the file system.
 
-*  Copyright (c) Qualcomm Innovation Center, Inc. All rights reserved.
-*  SPDX-License-Identifier: BSD-3-Clause-Clear
+*  Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+*  SPDX-License-Identifier: BSD-3-Clause
 */
 
 #include <stddef.h>

--- a/audio_memlogger/armemlog/inc/pal_state_queue.h
+++ b/audio_memlogger/armemlog/inc/pal_state_queue.h
@@ -6,8 +6,8 @@
 *      Defines memory structures & logging states
 *      for the PAL state memory queue.
 *
-*  Copyright (c) Qualcomm Innovation Center, Inc. All rights reserved.
-*  SPDX-License-Identifier: BSD-3-Clause-Clear
+*  Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+*  SPDX-License-Identifier: BSD-3-Clause
 */
 
 #define STATE_DEVICE_MAX_SIZE 3

--- a/audio_memlogger/armemlog/inc/spf_reset_queue.h
+++ b/audio_memlogger/armemlog/inc/spf_reset_queue.h
@@ -6,8 +6,8 @@
 *      Defines memory structures & logging states
 *      for the SPF reset memory queue.
 *
-*  Copyright (c) Qualcomm Innovation Center, Inc. All rights reserved.
-*  SPDX-License-Identifier: BSD-3-Clause-Clear
+*  Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+*  SPDX-License-Identifier: BSD-3-Clause
 */
 
 #include <stdint.h>

--- a/audio_memlogger/armemlog/parser/config.xml
+++ b/audio_memlogger/armemlog/parser/config.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" ?>
 <!--Config file for mem logger parser -->
 <!--Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries. -->
-<!--SPDX-License-Identifier: BSD-3-Clause-Clear -->
+<!--SPDX-License-Identifier: BSD-3-Clause -->
 <mem_logger>
     <queues>
         <KPI_QUEUE format="@QH61s?" />

--- a/audio_memlogger/armemlog/parser/enum_replacements.xml
+++ b/audio_memlogger/armemlog/parser/enum_replacements.xml
@@ -1,6 +1,6 @@
 <!--Enum replacements file for mem logger parser
     Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-    SPDX-License-Identifier: BSD-3-Clause-Clear.-->
+    SPDX-License-Identifier: BSD-3-Clause.-->
 <root>
 	<pal_stream_type_t>
 		<item name = "LOW_LATENCY" value = "1" />

--- a/audio_memlogger/armemlog/parser/graph_parser.py
+++ b/audio_memlogger/armemlog/parser/graph_parser.py
@@ -1,6 +1,6 @@
 #    Graph Parser file for mem logger
-#    Copyright (c) Qualcomm Innovation Center, Inc. All rights reserved.
-#    SPDX-License-Identifier: BSD-3-Clause-Clear
+#    Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+#    SPDX-License-Identifier: BSD-3-Clause
 from struct import iter_unpack
 import sys
 import os

--- a/audio_memlogger/armemlog/parser/header.py
+++ b/audio_memlogger/armemlog/parser/header.py
@@ -1,6 +1,6 @@
 #    Header parser file for mem logger
-#    Copyright (c) Qualcomm Innovation Center, Inc. All rights reserved.
-#    SPDX-License-Identifier: BSD-3-Clause-Clear
+#    Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+#    SPDX-License-Identifier: BSD-3-Clause
 import sys
 from xml.dom import minidom
 import re

--- a/audio_memlogger/armemlog/parser/kpi_parser.py
+++ b/audio_memlogger/armemlog/parser/kpi_parser.py
@@ -1,6 +1,6 @@
 #    KPI Parser file for mem logger
-#    Copyright (c) Qualcomm Innovation Center, Inc. All rights reserved.
-#    SPDX-License-Identifier: BSD-3-Clause-Clear
+#    Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+#    SPDX-License-Identifier: BSD-3-Clause
 from struct import unpack, iter_unpack, calcsize
 from datetime import datetime
 import sys

--- a/audio_memlogger/armemlog/parser/memLoggerParser.py
+++ b/audio_memlogger/armemlog/parser/memLoggerParser.py
@@ -1,6 +1,6 @@
 #    Main Parser file for mem logger
-#    Copyright (c) Qualcomm Innovation Center, Inc. All rights reserved.
-#    SPDX-License-Identifier: BSD-3-Clause-Clear
+#    Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+#    SPDX-License-Identifier: BSD-3-Clause
 import sys
 import os
 import memLoggerUtils

--- a/audio_memlogger/armemlog/parser/memLoggerUtils.py
+++ b/audio_memlogger/armemlog/parser/memLoggerUtils.py
@@ -1,6 +1,6 @@
 #    Utility functions for Parser for mem logger
-#    Copyright (c) Qualcomm Innovation Center, Inc. All rights reserved.
-#    SPDX-License-Identifier: BSD-3-Clause-Clear
+#    Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+#    SPDX-License-Identifier: BSD-3-Clause
 from xml.dom import minidom
 from datetime import datetime
 import io

--- a/audio_memlogger/armemlog/parser/spf_reset_parser.py
+++ b/audio_memlogger/armemlog/parser/spf_reset_parser.py
@@ -1,6 +1,6 @@
 #    SPF Reset Parser file for mem logger
-#    Copyright (c) Qualcomm Innovation Center, Inc. All rights reserved.
-#    SPDX-License-Identifier: BSD-3-Clause-Clear
+#    Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+#    SPDX-License-Identifier: BSD-3-Clause
 from struct import iter_unpack
 import sys
 import os

--- a/audio_memlogger/armemlog/parser/state_parser.py
+++ b/audio_memlogger/armemlog/parser/state_parser.py
@@ -1,6 +1,6 @@
 #    PAL State Parser file for mem logger
-#    Copyright (c) Qualcomm Innovation Center, Inc. All rights reserved.
-#    SPDX-License-Identifier: BSD-3-Clause-Clear
+#    Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+#    SPDX-License-Identifier: BSD-3-Clause
 from struct import unpack, unpack_from, calcsize
 from datetime import datetime
 import sys

--- a/audio_memlogger/armemlog/src/mem_logger.cpp
+++ b/audio_memlogger/armemlog/src/mem_logger.cpp
@@ -5,8 +5,8 @@
  * \brief
  *      Defines implementation for a circular queue.
  * \cond
- *  Copyright (c) Qualcomm Innovation Center, Inc. All rights reserved.
- *  SPDX-License-Identifier: BSD-3-Clause-Clear
+ *  Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ *  SPDX-License-Identifier: BSD-3-Clause
  * \endcond
  *
  */

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
-# SPDX-License-Identifier: BSD-3-Clause-Clear
+# SPDX-License-Identifier: BSD-3-Clause
 #
-# Copyright (c) 2025 Qualcomm Innovation Center, Inc. All rights reserved.
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 set -ex
 
 PREBUILD_SCRIPT_PATH="${PREBUILD_SCRIPT:-$(dirname "${BASH_SOURCE[0]}")/pre_build.sh}"

--- a/ci/files_to_copy.sh
+++ b/ci/files_to_copy.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
-# SPDX-License-Identifier: BSD-3-Clause-Clear
+# SPDX-License-Identifier: BSD-3-Clause
 #
-# Copyright (c) 2025 Qualcomm Innovation Center, Inc. All rights reserved.
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 
 # Move outside the github workspace to avoid conflicts
 cd ..

--- a/ci/knp_build.sh
+++ b/ci/knp_build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
-# SPDX-License-Identifier: BSD-3-Clause-Clear
+# SPDX-License-Identifier: BSD-3-Clause
 #
-# Copyright (c) 2025 Qualcomm Innovation Center, Inc. All rights reserved.
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 set -ex
 echo "Running build script..."
 # Build/Compile audioreach-utils

--- a/ci/pkl_build.sh
+++ b/ci/pkl_build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
-# SPDX-License-Identifier: BSD-3-Clause-Clear
+# SPDX-License-Identifier: BSD-3-Clause
 #
-# Copyright (c) 2025 Qualcomm Innovation Center, Inc. All rights reserved.
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 set -ex
 echo "Running build script..."
 # Build/Compile audioreach-utils


### PR DESCRIPTION
- Replaced "Qualcomm Innovation Center, Inc." with "Qualcomm Technologies, Inc. and/or its subsidiaries" across multiple source files.
- Update SPDX identifier from BSD-3-Clause-Clear to BSD-3-Clause

This aligns copyright attribution with current corporate naming conventions.