### PR TITLE
Enable Kaanapali and Pakala target compilation

### DIFF
--- a/ci/knp_build.sh
+++ b/ci/knp_build.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+#
+# Copyright (c) 2025 Qualcomm Innovation Center, Inc. All rights reserved.
+set -ex
+echo "Running build script..."
+# Build/Compile audioreach-utils
+source ${GITHUB_WORKSPACE}/install/environment-setup-armv8-6a-qcom-linux
+
+# make sure we are in the right directory
+cd ${GITHUB_WORKSPACE}/audio-route
+autoreconf -Wcross --verbose --install --force --exclude=autopoint
+autoconf --force
+
+
+# Run the configure script with the specified arguments
+./configure ${BUILD_ARGS}
+make DESTDIR=${GITHUB_WORKSPACE}/build install

--- a/ci/pkl_build.sh
+++ b/ci/pkl_build.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+#
+# Copyright (c) 2025 Qualcomm Innovation Center, Inc. All rights reserved.
+set -ex
+echo "Running build script..."
+# Build/Compile audioreach-utils
+source ${GITHUB_WORKSPACE}/install/environment-setup-armv8-7a-qcom-linux
+
+# make sure we are in the right directory
+cd ${GITHUB_WORKSPACE}/audio-route
+autoreconf -Wcross --verbose --install --force --exclude=autopoint
+autoconf --force
+
+
+# Run the configure script with the specified arguments
+./configure ${BUILD_ARGS}
+make DESTDIR=${GITHUB_WORKSPACE}/build install


### PR DESCRIPTION
Add build scripts to enable Kaanapali and Pakala target compilation.[1]

[1] https://github.com/AudioReach/audioreach-workflows/pull/69