### PR TITLE
Update repolint to use Qualcomm upstream and license patterns

### DIFF
--- a/repolint.json
+++ b/repolint.json
@@ -1,5 +1,5 @@
 {
-  "extends": "https://raw.githubusercontent.com/quic/.github/main/repolint.json",
+  "extends": "https://raw.githubusercontent.com/qualcomm/.github/main/repolint.json",
   "rules": {
     "source-license-headers-exist": {
       "level": "error",
@@ -28,7 +28,7 @@
           },
           "lineCount": 60,
           "patterns": [
-            "(Copyright|©).*Qualcomm Innovation Center, Inc|Copyright (\\(c\\)|©) (20(1[2-9]|2[0-2])(-|,|\\s)*)+ The Linux Foundation",
+            "(Copyright|©).*Qualcomm Innovation Center, Inc|Qualcomm Technologies, Inc|Copyright (\\(c\\)|©) (20(1[2-9]|2[0-2])(-|,|\\s)*)+ The Linux Foundation",
             "SPDX-License-Identifier|Redistribution and use in source and binary forms, with or without"
           ],
           "flags": "i"


### PR DESCRIPTION
Switch repolint to the Qualcomm .github upstream and extend license pattern checks to include Qualcomm Technologies, Inc.