### PR TITLE
build: add top-level autotools files for audio-utils

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,0 +1,1 @@
+SUBDIRS = audio-route

--- a/configure.ac
+++ b/configure.ac
@@ -1,0 +1,34 @@
+# Process this file with autoconf to produce a configure script
+
+# Requires autoconf tool later than 2.61
+AC_PREREQ(2.69)
+# Initialize the smwrapper package version 1.0.0
+AC_INIT([audioreach-audio-utils],1.0.0)
+# Does not strictly follow GNU Coding standards
+AM_INIT_AUTOMAKE([foreign subdir-objects])
+
+# Checks for programs.
+AC_PROG_CC
+AM_PROG_CC_C_O
+AC_PROG_CXX
+AC_PROG_LIBTOOL
+AC_PROG_AWK
+AC_PROG_CPP
+AC_PROG_INSTALL
+AC_PROG_LN_S
+AC_PROG_MAKE_SET
+PKG_PROG_PKG_CONFIG
+
+m4_define([LT_MAJOR], [1])
+m4_define([LT_MINOR], [0])
+m4_define([LT_PATCH], [0])
+
+AC_SUBST([LT_VERSION], LT_MAJOR.LT_MINOR.LT_PATCH)
+AC_SUBST([LT_VERSION_NUMBER], LT_MAJOR:LT_MINOR:LT_PATCH)
+
+AC_CONFIG_SUBDIRS([
+        audio-route
+])
+
+AC_CONFIG_FILES([ Makefile])
+AC_OUTPUT


### PR DESCRIPTION
Add top-level Makefile.am and configure.ac for audioreach-audio-utils.
Define the root autotools entry points and hook the audio-route subdirectory into the build.
Fixes build issues in Debian and Yocto workflows where a top-level configure script is required.
